### PR TITLE
Fix build error

### DIFF
--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -247,6 +247,7 @@ fn run_transactions_dos(
             is_final: true,
             max_len: None,
             skip_fee_check: true, // skip_fee_check
+            priority_fees: None,
         });
 
         process_command(&config).expect("deploy didn't pass");


### PR DESCRIPTION
#### Problem

This missing param causes a build error on my machine:

rustc 1.73.0 (cc66ad468 2023-10-03)
2.6 GHz 6-Core Intel Core i7